### PR TITLE
Update scene.mdx

### DIFF
--- a/packages/docs/docs/guide/features/scene.mdx
+++ b/packages/docs/docs/guide/features/scene.mdx
@@ -135,8 +135,8 @@ You have the option to ignore a node and its children, or just its children.
 ```js
 // Example of ignoring a node
 const manyChildren = new Container();
-manyChildren.__devtoolsIgnore = true;
-manyChildren.__devtoolsIgnoreChildren = true;
+manyChildren.__devtoolIgnore = true;
+manyChildren.__devtoolIgnoreChildren = "true";
 ```
 
 :::info


### PR DESCRIPTION
The documentation mistakenly listed __devtoolsIgnore and __devtoolsIgnoreChildren, which do not exist. The correct property names are __devtoolIgnore and __devtoolIgnoreChildren. Additionally, __devtoolIgnoreChildren is of type string, not boolean.