### PR TITLE
Add visibility switcher button to the element tree

### DIFF
--- a/packages/api/src/extensions/tree.ts
+++ b/packages/api/src/extensions/tree.ts
@@ -28,6 +28,7 @@ export type ContextMenuButtonMetadata = Omit<ButtonMetadata, 'type' | 'value'>;
 export interface PixiMetadata {
   type: PixiNodeType;
   locked?: boolean;
+  visible?: boolean;
   suffix?: string;
   buttons?: ButtonMetadata[];
   contextMenu?: ContextMenuButtonMetadata[];

--- a/packages/backend/src/scene/tree/tree.ts
+++ b/packages/backend/src/scene/tree/tree.ts
@@ -94,6 +94,7 @@ export class Tree extends PixiHandler {
       metadata: {
         type,
         locked: container.__devtoolLocked,
+        visible: container.visible,
         uid: this._getId(container),
         suffix,
         buttons: [],
@@ -127,6 +128,10 @@ export class Tree extends PixiHandler {
 
     if (buttonAction === 'locked') {
       node.__devtoolLocked = value;
+    }
+
+    if (buttonAction === 'visible') {
+      node.visible = value ?? true;
     }
 
     this._onButtonPressExtensions.forEach((ext) => {

--- a/packages/frontend/src/pages/scene/graph/tree/node-trigger.tsx
+++ b/packages/frontend/src/pages/scene/graph/tree/node-trigger.tsx
@@ -4,6 +4,8 @@ import {
   FaMinus as LayerIconOpen,
   FaLock as LockIcon,
   FaLockOpen as LockOpenIcon,
+  FaEye as VisibleIcon,
+  FaEyeSlash as HiddenIcon,
   // FaRegObjectGroup as SceneNodeIcon,
 } from 'react-icons/fa6';
 import { Input } from '../../../../components/ui/input';
@@ -73,6 +75,21 @@ export const NodeTrigger: React.FC<{
         {node.data.metadata.buttons?.map((button, i) => (
           <CustomNodeButton key={node.id + button.name + i} node={node} button={button} bridge={bridge} />
         ))}
+        <TooltipWrapper
+          contentProps={{ side: 'left' }}
+          providerProps={{ delayDuration: 2500 }}
+          trigger={
+            <CustomNodeButton
+              asChild={true}
+              button={{ name: 'visible', type: 'toggle', value: node.data.metadata.visible ?? true }}
+              icon={(node.data.metadata.visible ?? true) ? <VisibleIcon /> : <HiddenIcon />}
+              node={node}
+              className="mt-[-2px] w-[20px] px-1 py-0.5"
+              bridge={bridge}
+            />
+          }
+          tip={'Toggle the visibility of the node.'}
+        />
         <TooltipWrapper
           contentProps={{ side: 'left' }}
           providerProps={{ delayDuration: 2500 }}

--- a/packages/frontend/src/pages/scene/graph/tree/node-trigger.tsx
+++ b/packages/frontend/src/pages/scene/graph/tree/node-trigger.tsx
@@ -82,7 +82,7 @@ export const NodeTrigger: React.FC<{
             <CustomNodeButton
               asChild={true}
               button={{ name: 'visible', type: 'toggle', value: node.data.metadata.visible ?? true }}
-              icon={(node.data.metadata.visible ?? true) ? <VisibleIcon /> : <HiddenIcon />}
+              icon={node.data.metadata.visible ?? true ? <VisibleIcon /> : <HiddenIcon />}
               node={node}
               className="mt-[-2px] w-[20px] px-1 py-0.5"
               bridge={bridge}


### PR DESCRIPTION
Adds a visibility toggle button (eye icon) next to the lock button on each node in the scene graph tree, so a node's visibility can be switched directly from the tree without opening the settings panel.

The button reflects the node's current visibility and toggles it per node via the existing tree node-button bridge.